### PR TITLE
Exclude graphql endpoint from csrf

### DIFF
--- a/code/theseus/settings.py
+++ b/code/theseus/settings.py
@@ -40,9 +40,11 @@ INSTALLED_APPS = [
     'django_filters',
     'graphene_django',
     'theseus.organizations',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -130,3 +132,16 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# CORS Configuration for local access
+# Only for the graphql endpoint
+
+CORS_ORIGIN_WHITELIST = ( 'localhost:3000', )
+
+CORS_URLS_REGEX = r'^/graphql$'
+
+CORS_ALLOW_METHODS = (
+    'GET',
+    'OPTIONS',
+    'POST',
+)

--- a/code/theseus/urls.py
+++ b/code/theseus/urls.py
@@ -15,10 +15,11 @@ Including another URLconf
 """
 from django.conf.urls import url, include
 from django.contrib import admin
+from django.views.decorators.csrf import csrf_exempt
 
 from graphene_django.views import GraphQLView
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^graphql', GraphQLView.as_view(graphiql=True)),
+    url(r'^graphql', csrf_exempt(GraphQLView.as_view(graphiql=True))),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ psycopg2
 graphene_django
 django-graphiql
 django-filter
+django-cors-headers


### PR DESCRIPTION
This keeps CSRF on for everything except the graphql endpoint.